### PR TITLE
Redesign homepage: hero, stats banner, flowing testimonials, structured footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,9 @@ dist-ssr
 # AI harness tooling (impeccable design skills/hooks) - keep local
 .claude/
 .gemini/
+
+# Brainstorming visual-companion working dir
+.superpowers/
+
+# Impeccable design-hook config - keep local
+.impeccable/

--- a/docs/superpowers/plans/2026-08-05-hero-vertical-marquee.md
+++ b/docs/superpowers/plans/2026-08-05-hero-vertical-marquee.md
@@ -1,0 +1,309 @@
+# Hero Vertical-Marquee Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the homepage hero's split/horizontal-marquee layout with centered content over a full-bleed background of portrait property photos in vertical columns that alternate up/down.
+
+**Architecture:** One client component (`src/components/Home/Header.tsx`) renders three stacked layers — a background of vertical image-marquee columns, a balanced dark overlay, and a centered content stack — inside one full-bleed `<section>`. CSS keyframes for the vertical scroll live in `globals.css`. Photos come from the `listings` prop the component already receives.
+
+**Tech Stack:** Next.js 14 App Router, React 18, TypeScript, Tailwind CSS. Plain `<img>` (no `next/image`). No test runner in this repo — verification is `npm run build` plus visual/overflow checks in the browser.
+
+## Global Constraints
+
+- Scope is `src/components/Home/Header.tsx` and `src/app/globals.css` **only**. No other file's behavior changes; `src/app/page.tsx` already passes `listings={listings}`.
+- Stay in the existing brand: deep green `#101a15`, gold accent `#e5a41b`, Montserrat (`font-display`). Do **not** change the type system or palette.
+- The hero is always dark regardless of light/dark theme — use the theme-independent `gradient-primary` base and hardcoded `#101a15` overlay values, never `bg-primary` (which flips to gold in dark mode).
+- Plain `<img>` only; background photos are decorative → `alt=""`.
+- Respect `prefers-reduced-motion: reduce` (animation off).
+- Badge copy is exactly **"Best properties in Kenya"**. Headline is exactly **"Homes chosen with the same care you'll live in them."** on two lines (desktop). CTAs: **"Book a site visit"** (opens `BookModal`) and **"Browse all homes"** (`next/link` → `/listings`). No em dashes in copy.
+
+---
+
+### Task 1: Vertical-marquee CSS
+
+**Files:**
+- Modify: `src/app/globals.css` (append near the existing keyframes)
+
+**Interfaces:**
+- Produces: CSS classes `.marquee-col-down` and `.marquee-col-up`, each consuming a `--marquee-duration` custom property; keyframes `marquee-down` / `marquee-up`.
+
+- [ ] **Step 1: Add the keyframes, classes, and reduced-motion rule**
+
+Append to `src/app/globals.css`:
+
+```css
+/* Vertical hero marquee (columns scroll up/down; content is duplicated so the loop is seamless) */
+@keyframes marquee-down {
+  from { transform: translateY(-50%); }
+  to   { transform: translateY(0); }
+}
+@keyframes marquee-up {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-50%); }
+}
+.marquee-col-down {
+  animation: marquee-down var(--marquee-duration, 28s) linear infinite;
+}
+.marquee-col-up {
+  animation: marquee-up var(--marquee-duration, 28s) linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .marquee-col-down,
+  .marquee-col-up { animation: none; }
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `npm run build`
+Expected: build succeeds (exit 0). (The classes aren't referenced yet; this only confirms the CSS is valid.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/app/globals.css
+git commit -m "feat(hero): add vertical marquee keyframes and reduced-motion rule"
+```
+
+---
+
+### Task 2: Rewrite the hero component
+
+**Files:**
+- Modify: `src/components/Home/Header.tsx` (full rewrite of the file's body; keep the file path, `"use client"`, and the `HeaderProps { listings: Listing[] }` signature)
+
+**Interfaces:**
+- Consumes: `.marquee-col-down` / `.marquee-col-up` + `--marquee-duration` from Task 1; `BookModal` from `@/Modal/BookModal`; `Listing` from `@/types` (fields used: `imageUrl: string`, `moreImages?: { imageUrl: string }[]`).
+- Produces: default-exported `Header` component (unchanged prop contract, so `src/app/page.tsx` needs no edit).
+
+- [ ] **Step 1: Replace the entire file contents**
+
+Write `src/components/Home/Header.tsx`:
+
+```tsx
+"use client"
+
+import { useState } from 'react'
+import Link from 'next/link'
+import BookModal from '@/Modal/BookModal'
+import type { Listing } from '@/types'
+
+interface HeaderProps {
+  listings: Listing[]
+}
+
+const FALLBACK_IMAGES = ['/images/hero.jpg', '/images/hero2.jpg']
+
+// One entry per column. Directions alternate; durations vary so columns never
+// move in lockstep. Desktop shows all 4; mobile shows the first 2 (see JSX).
+const COLUMNS = [
+  { dir: 'down' as const, duration: '27s' },
+  { dir: 'up' as const, duration: '34s' },
+  { dir: 'down' as const, duration: '23s' },
+  { dir: 'up' as const, duration: '30s' },
+]
+
+// Varied portrait heights (px) cycled down each column for a masonry wall.
+const HEIGHTS = [230, 300, 190, 260, 210, 280]
+
+// Flatten every listing's imageUrl + moreImages into a de-duplicated pool.
+function collectPhotos(listings: Listing[]): string[] {
+  const pool: string[] = []
+  for (const listing of listings) {
+    if (listing.imageUrl) pool.push(listing.imageUrl)
+    for (const more of listing.moreImages ?? []) {
+      if (more.imageUrl) pool.push(more.imageUrl)
+    }
+  }
+  const deduped = Array.from(new Set(pool))
+  return deduped.length ? deduped : FALLBACK_IMAGES
+}
+
+// Round-robin the pool into `count` columns of `perCol` photos each,
+// cycling the pool when it is smaller than the number of slots.
+function buildColumns(pool: string[], count: number, perCol: number): string[][] {
+  const cols: string[][] = Array.from({ length: count }, () => [])
+  let i = 0
+  for (let c = 0; c < count; c++) {
+    for (let r = 0; r < perCol; r++) {
+      cols[c].push(pool[i % pool.length])
+      i++
+    }
+  }
+  return cols
+}
+
+const Header = ({ listings }: HeaderProps) => {
+  const [isBookFormOpen, setIsBookFormOpen] = useState(false)
+
+  const pool = collectPhotos(listings)
+  const columns = buildColumns(pool, COLUMNS.length, HEIGHTS.length)
+
+  return (
+    <section className="relative overflow-hidden gradient-primary text-white min-h-[88vh] flex items-center">
+      {/* Layer 1: vertical marquee columns */}
+      <div className="absolute inset-0 flex gap-2.5 px-2.5" aria-hidden="true">
+        {columns.map((col, c) => {
+          const { dir, duration } = COLUMNS[c]
+          const doubled = [...col, ...col] // duplicate for a seamless translateY loop
+          return (
+            <div
+              key={c}
+              className={`flex-1 overflow-hidden ${c >= 2 ? 'hidden md:block' : ''}`}
+            >
+              <div
+                className={`flex flex-col gap-2.5 ${dir === 'down' ? 'marquee-col-down' : 'marquee-col-up'}`}
+                style={{ '--marquee-duration': duration } as React.CSSProperties}
+              >
+                {doubled.map((src, i) => (
+                  <div
+                    key={i}
+                    className="w-full rounded-xl overflow-hidden flex-shrink-0"
+                    style={{ height: HEIGHTS[i % HEIGHTS.length] }}
+                  >
+                    <img src={src} alt="" className="w-full h-full object-cover" />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Layer 2: balanced overlay (dark top/bottom, lighter middle, soft radial scrim) */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(180deg, rgba(16,26,21,.80), rgba(16,26,21,.34) 34%, rgba(16,26,21,.34) 66%, rgba(16,26,21,.90)), radial-gradient(74% 58% at 50% 50%, rgba(16,26,21,.60), rgba(16,26,21,0) 80%)',
+        }}
+      />
+
+      {/* Layer 3: centered content */}
+      <div className="relative z-10 mx-auto w-full max-w-5xl px-6 sm:px-10 py-20 flex flex-col items-center text-center gap-[clamp(22px,4vh,52px)]">
+        <span className="inline-flex items-center gap-2 border border-white/25 rounded-full px-5 py-2 text-xs sm:text-sm uppercase tracking-[0.08em] text-white/90 bg-[#101a15]/30 backdrop-blur-sm">
+          <span className="w-2 h-2 rounded-full bg-accent" />
+          Best properties in Kenya
+        </span>
+
+        <h1 className="font-display font-extrabold leading-[1.05] tracking-[-0.03em] text-[clamp(30px,6vw,64px)] [text-shadow:0_2px_30px_rgba(0,0,0,0.4)]">
+          Homes chosen with the same<br className="hidden md:block" /> care you&apos;ll live in them.
+        </h1>
+
+        <p className="text-white/80 max-w-[58ch] leading-relaxed text-[clamp(14px,1.5vw,20px)] [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]">
+          Vetted homes in Runda, Karen, Westlands, Lavington and Kilimani. Honest guidance, no pressure, and a site visit booked in minutes.
+        </p>
+
+        <div className="flex flex-wrap gap-4 justify-center">
+          <button
+            onClick={() => setIsBookFormOpen(true)}
+            className="gradient-gold text-accent-foreground rounded-xl px-7 py-4 text-base font-bold transition-all duration-300 hover:scale-105"
+          >
+            Book a site visit
+          </button>
+          <Link
+            href="/listings"
+            className="border border-white/30 text-white rounded-xl px-7 py-4 text-base font-medium bg-[#101a15]/20 hover:bg-white/10 transition-all duration-300"
+          >
+            Browse all homes
+          </Link>
+        </div>
+      </div>
+
+      {isBookFormOpen && (
+        <BookModal handleBookMenu={() => setIsBookFormOpen(false)} />
+      )}
+    </section>
+  )
+}
+
+export default Header
+```
+
+- [ ] **Step 2: Type-check / build**
+
+Run: `npm run build`
+Expected: build succeeds (exit 0), no TypeScript errors. If it fails with a stale-cache `MODULE_NOT_FOUND` for `pages/_document`, run `rm -rf .next` first, then rebuild.
+
+- [ ] **Step 3: Visual verification (desktop + mobile)**
+
+Start the dev server (`npm run dev`) and load `http://localhost:3000/`. Confirm:
+- Desktop (~1280px): **4** columns of portrait photos drifting, **alternating** up/down; centered content; headline on **two lines**; gold "Book a site visit" + outline "Browse all homes".
+- Mobile (~390px, devtools device mode): **2** columns; headline wraps naturally (no awkward break); **no horizontal scroll** (`document.documentElement.scrollWidth === document.documentElement.clientWidth`).
+- The page background/photos read clearly behind the text (overlay balanced, text legible).
+
+Fix and rebuild until all hold. (If the desktop headline wraps to three lines, lower the `64px` clamp cap slightly; if it looks cramped, nudge it up — the mockup target is ~64–72px on two lines.)
+
+- [ ] **Step 4: Reduced-motion check**
+
+In devtools, emulate `prefers-reduced-motion: reduce` (Rendering panel) and reload. Expected: columns are static (no scrolling), content still legible.
+
+- [ ] **Step 5: Booking + browse actions**
+
+Click "Book a site visit" → the `BookModal` opens. Click "Browse all homes" → routes to `/listings`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Home/Header.tsx
+git commit -m "feat(hero): centered content over vertical image marquee"
+```
+
+---
+
+### Task 3: Remove the now-unused horizontal marquee CSS
+
+**Files:**
+- Modify: `src/app/globals.css` (delete the old horizontal `marquee-left` keyframes/class if nothing else references them)
+
+**Interfaces:**
+- Consumes: nothing. Purely a cleanup task, safe to reject independently.
+
+- [ ] **Step 1: Confirm nothing else uses the old class**
+
+Run: `grep -rn "marquee-left" src/`
+Expected: **zero** matches (Task 2 removed the only usage). If any match remains outside `globals.css`, stop and leave the CSS in place.
+
+- [ ] **Step 2: Delete the old rule**
+
+If Step 1 returned only the `globals.css` definition (or nothing), remove the old block from `src/app/globals.css`:
+
+```css
+/* DELETE these if present — replaced by the vertical marquee */
+@keyframes marquee-left { from { transform: translateX(0); } to { transform: translateX(-50%); } }
+.marquee-left { animation: marquee-left var(--marquee-duration, 32s) linear infinite; }
+/* (and its reduced-motion entry for .marquee-left) */
+```
+
+- [ ] **Step 3: Verify**
+
+Run: `npm run build`
+Expected: build succeeds. Reload `/` and confirm the hero is unchanged (the old class was unused).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/app/globals.css
+git commit -m "chore(hero): remove unused horizontal marquee CSS"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- Centered content over vertical columns → Task 2 (Layer 1 + Layer 3). ✓
+- 4 desktop / 2 mobile columns → Task 2 (`hidden md:block` on columns 3–4). ✓
+- Alternating up/down, varied durations, seamless loop → Task 2 (`COLUMNS`, `doubled`) + Task 1 keyframes. ✓
+- Balanced overlay → Task 2 (Layer 2). ✓
+- Badge "Best properties in Kenya", two-line headline, subcopy, CTAs → Task 2 (Layer 3). ✓
+- Real Firestore photos (`imageUrl` + `moreImages`), cycled, local fallback → Task 2 (`collectPhotos` / `buildColumns` / `FALLBACK_IMAGES`). ✓
+- Reduced motion → Task 1 media query + Task 2 Step 4 check. ✓
+- globals.css keyframes + cleanup of old marquee → Tasks 1 and 3. ✓
+- Brand/theme-independent hero, plain `<img>`, no other files → Global Constraints, honored in Task 2. ✓
+
+**2. Placeholder scan:** No TBD/TODO; every code step has full content. ✓
+
+**3. Type consistency:** `collectPhotos(listings): string[]` → feeds `buildColumns(pool, count, perCol): string[][]`; `COLUMNS.length` (4) and `HEIGHTS.length` (6) are the `count`/`perCol` args; `--marquee-duration` set in Task 2 matches the class in Task 1. ✓
+
+No gaps found.

--- a/docs/superpowers/specs/2026-08-05-hero-vertical-marquee-redesign-design.md
+++ b/docs/superpowers/specs/2026-08-05-hero-vertical-marquee-redesign-design.md
@@ -1,0 +1,92 @@
+# Hero redesign — centered content over vertical image marquee
+
+**Date:** 2026-08-05
+**Branch:** `redesign`
+**Scope:** The homepage hero only (`src/components/Home/Header.tsx`). Nothing else on the site changes.
+
+## Context
+
+Today's hero is a two-column split: dark-green left side with a badge, headline, subcopy and two CTAs; right side is three rows of listing photos scrolling horizontally (a left-drifting marquee). It works, but the client wants a fresher, more immersive treatment.
+
+## Goal
+
+Replace the split layout with a **centered content block over a full-bleed background of portrait property photos arranged in vertical columns that drift up and down** (a "curtain" / masonry marquee). The home photos become the atmosphere; the message sits confidently in the middle. Stays entirely within the existing brand (deep green `#101a15`, gold `#e5a41b`, Montserrat) — this is a layout change to one component, not a design-system change.
+
+Approved visually through four iterations in the brainstorming visual companion (v4 is the agreed look).
+
+## Design
+
+### Structure
+
+A single full-bleed `<section>` (relative, `overflow-hidden`, `min-height` ~`88vh` on desktop, comfortable tall value on mobile) with three stacked layers:
+
+1. **Background** — the vertical image-marquee columns (absolute, fills the section).
+2. **Overlay** — a balanced dark wash so the content reads (absolute, above background).
+3. **Content** — the centered stack (absolute, above overlay, vertically + horizontally centered).
+
+### Background: vertical marquee columns
+
+- **4 columns** on desktop, **2 columns** on mobile. Columns sit side by side with a small gutter and fill the section height; each column clips its overflow.
+- Each column holds a stack of **portrait-cropped** photos (`object-cover`) at **varied heights** so the wall looks masonry, not gridded.
+- Each column's photo list is **duplicated back-to-back** so a `translateY` loop is seamless.
+- **Alternating direction:** columns go down / up / down / up. Each column gets a slightly different duration (≈ 23–34s) so they never move in lockstep.
+- Animation via CSS `transform: translateY` (GPU-friendly), added as keyframes in `globals.css`:
+  - down: `translateY(-50%)` → `translateY(0)`
+  - up: `translateY(0)` → `translateY(-50%)`
+- **Reduced motion:** under `prefers-reduced-motion: reduce`, animation is disabled (columns render static) — matching the pattern already used for the existing marquee.
+
+### Overlay
+
+Balanced for legibility without hiding the photos (the agreed v4 treatment):
+- A vertical gradient darker at the very top and bottom, lighter through the middle band.
+- Plus a soft radial scrim centered behind the content.
+- Content also carries subtle text-shadows as a second safety net.
+
+### Content (centered)
+
+Vertical stack, centered, with viewport-scaled spacing so it spreads out on large screens instead of clustering:
+
+1. **Badge** — pill with a gold dot: **"Best properties in Kenya"** (was "Nairobi's prime neighborhoods · verified listings"). Uppercase, subtle border, faint translucent background.
+2. **Headline (h1, bold, ~72px max):** two balanced lines —
+   "Homes chosen with the same" / "care you'll live in them."
+   Forced break on desktop; the break relaxes on mobile so it never looks awkward.
+3. **Subcopy:** "Vetted homes in Runda, Karen, Westlands, Lavington and Kilimani. Honest guidance, no pressure, and a site visit booked in minutes." (unchanged copy, ~58ch measure)
+4. **CTAs:** gold **"Book a site visit"** (opens the existing `BookModal`) + outline **"Browse all homes"** (`next/link` to `/listings`).
+
+Spacing, padding and type all use `clamp()` so the stack breathes on wide screens and stays compact on phones.
+
+### Data — real photos from Firestore
+
+`Header` already receives `listings: Listing[]` as a prop (server-fetched in `page.tsx`). `Listing` has `imageUrl: string` and optional `moreImages?: { imageUrl: string }[]`.
+
+- Build the photo pool: for each listing, take `imageUrl` plus every `moreImages[].imageUrl`; filter falsy; de-duplicate.
+- Distribute the pool round-robin across the columns (4 desktop / 2 mobile). If the pool is smaller than the slots needed, **cycle** it so every column is full.
+- If the pool is empty (fetch failed / no listings), fall back to the existing local `/images/hero.jpg` and `/images/hero2.jpg`.
+- Photos are decorative background → `alt=""`. Keep plain `<img>` (project convention; no `next/image` for dynamic Firebase URLs).
+
+## Files touched
+
+- `src/components/Home/Header.tsx` — rewrite the hero markup/logic (still `"use client"`, still takes `listings`, still opens `BookModal`).
+- `src/app/globals.css` — add vertical-marquee keyframes (down/up) + reduced-motion rule; the old horizontal `marquee-left` can be removed if nothing else uses it (verify first).
+- No prop/signature changes to `page.tsx` (it already passes `listings`).
+
+## Error handling / edge cases
+
+- **No/failed listings:** fall back to the two local hero images, cycled.
+- **Few photos:** cycle the pool so columns stay full and the loop still reads.
+- **Very short viewport (landscape phones):** `min-height` uses a sensible floor; content stays centered and scrolls with the page if needed.
+- **Reduced motion:** static columns, everything still legible.
+- **Slow image loads:** dark section background shows first; images fade in as they load (no layout shift — column heights are fixed).
+
+## Testing / verification
+
+- `npm run build` clean.
+- Headless screenshots at 390px (mobile, 2 columns) and ~1280px (desktop, 4 columns) via the Chrome-CDP harness already used this session — confirm: content centered and legible, headline on two lines (desktop), no horizontal overflow (`scrollWidth === clientWidth`), columns visibly alternating.
+- Verify `prefers-reduced-motion` disables the animation.
+- Confirm "Book a site visit" opens the modal and "Browse all homes" routes to `/listings`.
+
+## Out of scope
+
+- Any other page or component.
+- Changing the type system / palette (Montserrat and the gold-on-dark tokens stay).
+- Adding `next/image`, image CDN, or new data fetching.

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -104,6 +104,26 @@ html {
   }
 }
 
+/* Vertical hero marquee (columns scroll up/down; content is duplicated so the loop is seamless) */
+@keyframes marquee-down {
+  from { transform: translateY(-50%); }
+  to   { transform: translateY(0); }
+}
+@keyframes marquee-up {
+  from { transform: translateY(0); }
+  to   { transform: translateY(-50%); }
+}
+.marquee-col-down {
+  animation: marquee-down var(--marquee-duration, 28s) linear infinite;
+}
+.marquee-col-up {
+  animation: marquee-up var(--marquee-duration, 28s) linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .marquee-col-down,
+  .marquee-col-up { animation: none; }
+}
+
 .animate-fade-in-up {
   animation: fadeInUp 0.8s ease-out forwards;
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -85,25 +85,6 @@ html {
   }
 }
 
-@keyframes marquee-left {
-  from {
-    transform: translateX(0);
-  }
-  to {
-    transform: translateX(-50%);
-  }
-}
-
-.marquee-left {
-  animation: marquee-left var(--marquee-duration, 32s) linear infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .marquee-left {
-    animation: none;
-  }
-}
-
 /* Vertical hero marquee (columns scroll up/down; content is duplicated so the loop is seamless) */
 @keyframes marquee-down {
   from { transform: translateY(-50%); }

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -97,13 +97,13 @@ const Header = ({ listings }: HeaderProps) => {
       />
 
       {/* Layer 3: centered content */}
-      <div className="relative z-10 mx-auto w-full max-w-5xl px-6 sm:px-10 py-20 flex flex-col items-center text-center gap-[clamp(22px,4vh,52px)]">
+      <div className="relative z-10 mx-auto w-full max-w-6xl px-6 sm:px-10 py-20 flex flex-col items-center text-center gap-[clamp(22px,4vh,52px)]">
         <span className="inline-flex items-center gap-2 border border-white/25 rounded-full px-5 py-2 text-xs sm:text-sm uppercase tracking-[0.08em] text-white/90 bg-[#101a15]/30 backdrop-blur-sm">
           <span className="w-2 h-2 rounded-full bg-accent" />
           Best properties in Kenya
         </span>
 
-        <h1 className="font-display font-extrabold leading-[1.05] tracking-[-0.03em] text-[clamp(30px,6vw,64px)] [text-shadow:0_2px_30px_rgba(0,0,0,0.4)]">
+        <h1 className="font-display font-extrabold leading-[1.05] tracking-[-0.03em] text-[clamp(30px,5.6vw,64px)] [text-shadow:0_2px_30px_rgba(0,0,0,0.4)]">
           Homes chosen with the same<br className="hidden md:block" /> care you&apos;ll live in them.
         </h1>
 

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -10,78 +10,120 @@ interface HeaderProps {
 }
 
 const FALLBACK_IMAGES = ['/images/hero.jpg', '/images/hero2.jpg']
-const ROW_DURATIONS = ['40s', '32s', '25s']
 
-function marqueeRow(images: string[], fallback: string[]) {
-  const base = images.length ? images : fallback
-  // Duplicate so translateX(-50%) loops back to an identical frame.
-  return [...base, ...base]
+// One entry per column. Directions alternate; durations vary so columns never
+// move in lockstep. Desktop shows all 4; mobile shows the first 2 (see JSX).
+const COLUMNS = [
+  { dir: 'down' as const, duration: '27s' },
+  { dir: 'up' as const, duration: '34s' },
+  { dir: 'down' as const, duration: '23s' },
+  { dir: 'up' as const, duration: '30s' },
+]
+
+// Varied portrait heights (px) cycled down each column for a masonry wall.
+const HEIGHTS = [230, 300, 190, 260, 210, 280]
+
+// Flatten every listing's imageUrl + moreImages into a de-duplicated pool.
+function collectPhotos(listings: Listing[]): string[] {
+  const pool: string[] = []
+  for (const listing of listings) {
+    if (listing.imageUrl) pool.push(listing.imageUrl)
+    for (const more of listing.moreImages ?? []) {
+      if (more.imageUrl) pool.push(more.imageUrl)
+    }
+  }
+  const deduped = Array.from(new Set(pool))
+  return deduped.length ? deduped : FALLBACK_IMAGES
+}
+
+// Round-robin the pool into `count` columns of `perCol` photos each,
+// cycling the pool when it is smaller than the number of slots.
+function buildColumns(pool: string[], count: number, perCol: number): string[][] {
+  const cols: string[][] = Array.from({ length: count }, () => [])
+  let i = 0
+  for (let c = 0; c < count; c++) {
+    for (let r = 0; r < perCol; r++) {
+      cols[c].push(pool[i % pool.length])
+      i++
+    }
+  }
+  return cols
 }
 
 const Header = ({ listings }: HeaderProps) => {
   const [isBookFormOpen, setIsBookFormOpen] = useState(false)
 
-  const photos = listings.map((listing) => listing.imageUrl).filter(Boolean).slice(0, 12)
-  const rows = [0, 1, 2].map((rowIndex) =>
-    marqueeRow(photos.filter((_, i) => i % 3 === rowIndex), FALLBACK_IMAGES)
-  )
+  const pool = collectPhotos(listings)
+  const columns = buildColumns(pool, COLUMNS.length, HEIGHTS.length)
 
   return (
-    <section className="gradient-primary text-white overflow-hidden">
-      <div className="max-w-[1400px] mx-auto">
-        <div className="px-6 sm:px-10 lg:px-12 pt-16 sm:pt-20 lg:pt-20">
-          <div className="inline-flex items-center gap-2 border border-white/15 rounded-full px-4 py-2 text-xs sm:text-sm text-white/70 mb-7">
-            <span className="w-[7px] h-[7px] rounded-full bg-accent inline-block" />
-            Nairobi&apos;s prime neighborhoods · verified listings
-          </div>
-        </div>
-
-        <div className="grid grid-cols-1 lg:grid-cols-2 pb-12 lg:pb-20">
-          {/* Left: content, top-aligned with bottom-anchored CTAs to mirror the image column's height */}
-          <div className="min-w-0 px-6 sm:px-10 lg:px-12 flex flex-col lg:justify-between">
-            <div>
-              <h1 className="font-display text-4xl sm:text-6xl lg:text-6xl leading-[0.98] tracking-tight mb-6 max-w-xl">
-                Homes chosen with the same care you&apos;ll live in them.
-              </h1>
-
-              <p className="text-lg sm:text-xl text-white/70 leading-relaxed max-w-lg mb-8 lg:mb-0">
-                Lamona Realtors connects home buyers with vetted properties in Runda, Karen, Westlands, Lavington and Kilimani. Honest guidance, no pressure, and a site visit booked in minutes.
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-3">
-              <button
-                onClick={() => setIsBookFormOpen(true)}
-                className="gradient-gold text-accent-foreground rounded-lg px-8 py-4 text-base font-bold transition-all duration-300 hover:scale-105"
+    <section className="relative overflow-hidden gradient-primary text-white min-h-[88vh] flex items-center">
+      {/* Layer 1: vertical marquee columns */}
+      <div className="absolute inset-0 flex gap-2.5 px-2.5" aria-hidden="true">
+        {columns.map((col, c) => {
+          const { dir, duration } = COLUMNS[c]
+          const doubled = [...col, ...col] // duplicate for a seamless translateY loop
+          return (
+            <div
+              key={c}
+              className={`flex-1 overflow-hidden ${c >= 2 ? 'hidden md:block' : ''}`}
+            >
+              <div
+                className={`flex flex-col gap-2.5 ${dir === 'down' ? 'marquee-col-down' : 'marquee-col-up'}`}
+                style={{ '--marquee-duration': duration } as React.CSSProperties}
               >
-                Book a site visit
-              </button>
-              <Link
-                href="/listings"
-                className="border border-white/20 text-white rounded-lg px-8 py-4 text-base font-medium hover:bg-white/10 transition-all duration-300"
-              >
-                Browse all homes
-              </Link>
-            </div>
-          </div>
-
-          {/* Right: scrolling house photos, spanning the same top-to-bottom height as the left column */}
-          <div className="min-w-0 flex flex-col gap-3 justify-center h-[360px] sm:h-[480px] lg:h-auto lg:gap-0 lg:justify-between py-8 lg:py-0">
-            {rows.map((row, rowIndex) => (
-              <div key={rowIndex} className="overflow-hidden">
-                <div
-                  className="flex gap-3 w-max marquee-left"
-                  style={{ "--marquee-duration": ROW_DURATIONS[rowIndex] } as React.CSSProperties}
-                >
-                  {row.map((src, i) => (
-                    <div key={i} className="w-36 sm:w-52 h-24 sm:h-32 rounded-2xl overflow-hidden flex-shrink-0">
-                      <img src={src} alt="" className="w-full h-full object-cover" />
-                    </div>
-                  ))}
-                </div>
+                {doubled.map((src, i) => (
+                  <div
+                    key={i}
+                    className="w-full rounded-xl overflow-hidden flex-shrink-0"
+                    style={{ height: HEIGHTS[i % HEIGHTS.length] }}
+                  >
+                    <img src={src} alt="" className="w-full h-full object-cover" />
+                  </div>
+                ))}
               </div>
-            ))}
-          </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Layer 2: balanced overlay (dark top/bottom, lighter middle, soft radial scrim) */}
+      <div
+        className="absolute inset-0"
+        style={{
+          background:
+            'linear-gradient(180deg, rgba(16,26,21,.80), rgba(16,26,21,.34) 34%, rgba(16,26,21,.34) 66%, rgba(16,26,21,.90)), radial-gradient(74% 58% at 50% 50%, rgba(16,26,21,.60), rgba(16,26,21,0) 80%)',
+        }}
+      />
+
+      {/* Layer 3: centered content */}
+      <div className="relative z-10 mx-auto w-full max-w-5xl px-6 sm:px-10 py-20 flex flex-col items-center text-center gap-[clamp(22px,4vh,52px)]">
+        <span className="inline-flex items-center gap-2 border border-white/25 rounded-full px-5 py-2 text-xs sm:text-sm uppercase tracking-[0.08em] text-white/90 bg-[#101a15]/30 backdrop-blur-sm">
+          <span className="w-2 h-2 rounded-full bg-accent" />
+          Best properties in Kenya
+        </span>
+
+        <h1 className="font-display font-extrabold leading-[1.05] tracking-[-0.03em] text-[clamp(30px,6vw,64px)] [text-shadow:0_2px_30px_rgba(0,0,0,0.4)]">
+          Homes chosen with the same<br className="hidden md:block" /> care you&apos;ll live in them.
+        </h1>
+
+        <p className="text-white/80 max-w-[58ch] leading-relaxed text-[clamp(14px,1.5vw,20px)] [text-shadow:0_1px_12px_rgba(0,0,0,0.4)]">
+          Vetted homes in Runda, Karen, Westlands, Lavington and Kilimani. Honest guidance, no pressure, and a site visit booked in minutes.
+        </p>
+
+        <div className="flex flex-wrap gap-4 justify-center">
+          <button
+            onClick={() => setIsBookFormOpen(true)}
+            className="gradient-gold text-accent-foreground rounded-xl px-7 py-4 text-base font-bold transition-all duration-300 hover:scale-105"
+          >
+            Book a site visit
+          </button>
+          <Link
+            href="/listings"
+            className="border border-white/30 text-white rounded-xl px-7 py-4 text-base font-medium bg-[#101a15]/20 hover:bg-white/10 transition-all duration-300"
+          >
+            Browse all homes
+          </Link>
         </div>
       </div>
 


### PR DESCRIPTION
## What

Redesigns the homepage hero. The old split layout (dark-left text / right horizontal-scrolling image row) is replaced with **centered content over a full-bleed background of portrait property photos in vertical columns that alternate up/down** (a masonry "curtain"), with a balanced dark overlay so the content stays legible.

Approved visually through four iterations in the brainstorming visual companion (v4).

## Changes

- **`src/components/Home/Header.tsx`** — full rewrite: photo pool from `listings` (`imageUrl` + `moreImages`, de-duplicated, cycled across columns, local fallback when empty); 4 columns on desktop / 2 on mobile; alternating up/down motion with seamless duplicated loops; balanced overlay; centered stack with badge **"Best properties in Kenya"**, a two-line headline, and the "Book a site visit" / "Browse all homes" CTAs.
- **`src/app/globals.css`** — added vertical marquee keyframes (`marquee-down`/`marquee-up`) + `prefers-reduced-motion` rule; removed the now-unused horizontal `marquee-left` block.
- Docs: design spec + implementation plan under `docs/superpowers/`.

Scope is the hero only — no other page, and the type system / gold-on-dark palette are unchanged. The hero stays dark in both light and dark themes (`gradient-primary`, never `bg-primary`).

## Verification

- `npm run build` clean.
- Headless Chrome checks: two-line headline at 800/1280/1440px, natural wrap on 390px mobile, 4 desktop / 2 mobile columns, no horizontal overflow, real Firestore photos rendering, both CTAs present, `prefers-reduced-motion` disables the animation.

## Notes / follow-ups (non-blocking)

- Hero subcopy now reads "Vetted homes in Runda, Karen, Westlands, Lavington and Kilimani…" (the approved v4 copy); it drops the old "Lamona Realtors connects home buyers with…" opening, so the brand name is no longer in the hero body (still in the nav logo).
- Minor perf follow-ups: mobile still fetches the two hidden desktop columns' `<img>` (low impact — small cycled pool, mostly duplicate URLs); no `loading`/`fetchpriority` hints on hero images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)